### PR TITLE
Add remote check script

### DIFF
--- a/bin/check-plugin-by-slug.php
+++ b/bin/check-plugin-by-slug.php
@@ -93,11 +93,11 @@ if ( empty( $opts['slug'] ) ) {
 	$slugs = [ $opts['slug'] ];
 }
 
-foreach ( $slugs as $slug ) {
+// Do we need a fresh object each time?
+$phpcs = new PHPCS();
+$phpcs->set_standard( dirname( __DIR__ ) . '/rulesets/reviewer-flags.xml' );
 
-	// Do we need a fresh object each time?
-	$phpcs = new PHPCS();
-	$phpcs->set_standard( dirname( __DIR__ ) . '/rulesets/reviewer-flags.xml' );
+foreach ( $slugs as $slug ) {
 
 	$path = export_plugin( $slug );
 	$args = array(

--- a/bin/check-plugin-by-slug.php
+++ b/bin/check-plugin-by-slug.php
@@ -1,0 +1,127 @@
+#!/usr/bin/php
+<?php
+/**
+ * A quick and dirty script for testing the PHPCS class against any plugin in the directory.
+ * This script does not use or require WordPress.
+ *
+ * Usage:
+ * php check-plugin-by-slug.php --slug akismet
+ * Or:
+ * php check-plugin-by-slug.php
+ */
+
+use WordPressDotOrg\Code_Analysis\PHPCS;
+
+// This script should only be called in a CLI environment.
+if ( 'cli' != php_sapi_name() ) {
+	die();
+}
+
+$opts = getopt( '', array( 'slug:', 'report:' ) );
+if ( empty( $opts['report'] ) ) {
+	$opts['report'] = 'summary';
+}
+
+// Fetch the slugs of the top plugins in the directory
+function get_top_slugs( $plugins_to_retrieve ) {
+	$payload = array(
+		'action' => 'query_plugins',
+		'request' => serialize( (object) array( 'browse' => 'popular', 'per_page' => $plugins_to_retrieve ) ) );
+
+	$ch = curl_init();
+	curl_setopt($ch, CURLOPT_URL,"https://api.wordpress.org/plugins/info/1.0/");
+	curl_setopt($ch, CURLOPT_POST, true);
+	curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+	curl_setopt($ch, CURLOPT_POSTFIELDS, $payload );
+
+	$response = curl_exec( $ch );
+
+	$data = unserialize( $response );
+
+	curl_close( $ch );
+
+	$out = [];
+
+	foreach ( $data->plugins as $plugin ) {
+		$out[] = $plugin->slug;
+	}
+
+	return $out;
+}
+
+// Export a plugin to ./plugins/SLUG and return the full path to that directory
+function export_plugin( $slug ) {
+
+	$tmpnam = tempnam( '/tmp', 'plugin-' . $slug );
+	if ( $tmpnam ) {
+		$tmpnam = realpath( $tmpnam );
+		unlink( $tmpnam );
+		mkdir( $tmpnam ) || die( "Failed creating temp directory $tmpnam" );
+		$cmd = "svn export --force https://plugins.svn.wordpress.org/" . $slug . "/trunk " . $tmpnam;
+		shell_exec( $cmd );
+
+		return $tmpnam;
+	}
+}
+
+// Fake WP_Error class so the PHPCS class works
+class WP_Error {
+	var $code;
+	var $message;
+	var $data;
+
+	function __construct( $code = '', $message = '', $data = '' ) {
+		$this->code = $code;
+		$this->message = $message;
+		$this->data = $data;
+	}
+
+	public function __toString() {
+		return var_export( $this, true );
+	}
+}
+
+// Again so PHPCS class works
+define( 'WPINC', 'yeahnah' );
+
+// Load phpcs class
+require dirname( __DIR__ ) . '/includes/class-phpcs.php';
+
+if ( empty( $opts['slug'] ) ) {
+	$slugs = get_top_slugs( 25 );
+} else {
+	$slugs = [ $opts['slug'] ];
+}
+
+foreach ( $slugs as $slug ) {
+
+	// Do we need a fresh object each time?
+	$phpcs = new PHPCS();
+	$phpcs->set_standard( dirname( __DIR__ ) . '/rulesets/reviewer-flags.xml' );
+
+	$path = export_plugin( $slug );
+	$args = array(
+		'extensions' => 'php', // Only check php files.
+		's' => true, // Show the name of the sniff triggering a violation.
+	);
+
+	echo "Checking $slug in $path...\n";
+
+	switch ( $opts['report'] ) {
+		case 'full':
+			echo $phpcs->run_full_report( $path, $args );
+			break;
+		case 'json':
+			$result = $phpcs->run_json_report( $path, $args, 'array' );
+			if ( is_array( $result ) ) {
+				print_r( $result );
+			} else {
+				echo $result;
+			}
+			break;
+		case 'summary':
+		default:
+			echo $phpcs->run_summary_report( $path, $args );
+			break;
+	}
+}

--- a/bin/check-plugin-by-slug.php
+++ b/bin/check-plugin-by-slug.php
@@ -93,7 +93,6 @@ if ( empty( $opts['slug'] ) ) {
 	$slugs = [ $opts['slug'] ];
 }
 
-// Do we need a fresh object each time?
 $phpcs = new PHPCS();
 $phpcs->set_standard( dirname( __DIR__ ) . '/rulesets/reviewer-flags.xml' );
 

--- a/includes/class-phpcs.php
+++ b/includes/class-phpcs.php
@@ -49,7 +49,11 @@ class PHPCS {
 	 */
 	public function __construct() {
 		$this->phpcs = dirname( __DIR__ ) . '/vendor/squizlabs/php_codesniffer/bin/phpcs';
-		$this->cache_file = get_temp_dir() . 'wporg-code-analysis/phpcs-cache';
+		if ( is_callable( 'get_temp_dir' ) ) {
+			$this->cache_file = get_temp_dir() . 'wporg-code-analysis/phpcs-cache';
+		} else {
+			$this->cache_file = '/tmp/wporg-code-analysis/phpcs-cache';			
+		}
 	}
 
 	/**
@@ -89,7 +93,7 @@ class PHPCS {
 	 * @return void
 	 */
 	public function clear_cache() {
-		wp_delete_file( $this->cache_file );
+		@unlink( $this->cache_file );
 	}
 
 	/**


### PR DESCRIPTION
This is a variation on the CLI script that can be used to remotely test plugins from the plugin directory.

I made a few changes so it doesn't need WordPress to run.

`php bin/check-plugin-by-slug.php` will check the top 25 plugins from the directory.