### PR TITLE
Add less strict checks

### DIFF
--- a/bin/check-plugin-by-slug.php
+++ b/bin/check-plugin-by-slug.php
@@ -17,7 +17,7 @@ if ( 'cli' != php_sapi_name() ) {
 	die();
 }
 
-$opts = getopt( '', array( 'slug:', 'report:', 'page:', 'number:' ) );
+$opts = getopt( '', array( 'slug:', 'report:', 'page:', 'number:', 'errors' ) );
 if ( empty( $opts['report'] ) ) {
 	$opts['report'] = 'summary';
 }
@@ -114,6 +114,10 @@ foreach ( $slugs as $slug ) {
 		'extensions' => 'php', // Only check php files.
 		's' => true, // Show the name of the sniff triggering a violation.
 	);
+
+	if ( isset( $opts['errors'] ) ) {
+		$args[ 'n' ] = true;
+	}
 
 	echo str_repeat( '=', 80 ) . "\n";
 	echo "Checking $slug in $path...\n";

--- a/tests/db/DirectDBUnitTest.php
+++ b/tests/db/DirectDBUnitTest.php
@@ -15,7 +15,7 @@ class DisallowExtractSniffTest extends TestCase {
         $phpcsFile = new LocalFile($fixtureFile, $ruleset, $config);
         $phpcsFile->process();
         $foundErrors = $phpcsFile->getErrors();
-        $lines = array_keys($foundErrors);
+        $error_lines = array_keys($foundErrors);
 
         $this->assertEquals(
             [
@@ -29,13 +29,21 @@ class DisallowExtractSniffTest extends TestCase {
                 66,
                 75,
                 82,
-                89,
                 97,
                 106,
                 113,
                 120
             ], 
-            $lines);
+            $error_lines );
+
+        $warning_lines = array_keys( $phpcsFile->getWarnings() );
+
+        $this->assertEquals(
+            [
+                89,
+            ],
+            $warning_lines );
+
     }
 
     public function test_safe_code() {

--- a/tests/db/DirectDBUnitTest.php
+++ b/tests/db/DirectDBUnitTest.php
@@ -32,7 +32,8 @@ class DisallowExtractSniffTest extends TestCase {
                 97,
                 106,
                 113,
-                120
+                120,
+                140
             ], 
             $error_lines );
 

--- a/tests/db/DirectDBUnitTest.php-bad.inc
+++ b/tests/db/DirectDBUnitTest.php-bad.inc
@@ -120,3 +120,25 @@ function insecure_wpdb_query_13( $foo ) {
 	$bar = $wpdb->query( "SELECT * FROM $wpdb->users WHERE foo = '" . $foo . "' LIMIT 1" ); // unsafe
 }
 
+function insecure_wpdb_query_14() {
+	// Cribbed from some real code
+	global $wpdb;
+
+	parse_str( $_REQUEST['order'], $data );
+
+	if ( is_array( $data ) ) {
+			$id_arr = array( );
+			foreach ( $data as $key => $values ) {
+					foreach ( $values as $position => $id ) {
+							$id_arr[] = $id;
+					}
+			}
+
+
+			$menu_order_arr = array( );
+			foreach ( $id_arr as $key => $id ) {
+					$results = $wpdb->get_results( "SELECT menu_order FROM $wpdb->posts WHERE ID = " . $id ); // unsafe
+			}
+
+	}
+}


### PR DESCRIPTION
This turns some errors into warnings, and adds a CLI option `--errors` which will ignore warnings and report only the more serious errors.