### PR TITLE
Reduce false positives and unnecessary errors

### DIFF
--- a/MinimalPluginStandard/Sniffs/DirectDBSniff.php
+++ b/MinimalPluginStandard/Sniffs/DirectDBSniff.php
@@ -43,6 +43,16 @@ class DirectDBSniff extends Sniff {
 	protected $unslashingFunctions = array();
 
 	/**
+	 * Functions that are neither safe nor unsafe. Their output is as safe as the data passed as parameters.
+	 */
+	protected $neutralFunctions = array(
+		'implode'      => true,
+		'join'         => true,
+		'array_keys'   => true,
+		'array_values' => true,
+	);
+
+	/**
 	 * $wpdb methods with escaping built-in
 	 *
 	 * @var array[]
@@ -339,6 +349,17 @@ class DirectDBSniff extends Sniff {
 						// Something went wrong here
 						return false;
 					}
+				} elseif ( isset( $this->neutralFunctions[ $this->tokens[ $newPtr ][ 'content' ] ] ) ) {
+					// It's a function like implode(), which is safe if all of the parameters are also safe.
+					$function_params = PassedParameters::getParameters( $this->phpcsFile, $newPtr );
+					foreach ( $function_params as $param ) {
+						if ( !$this->expression_is_safe( $param[ 'start' ], $param[ 'end' ] + 1 ) ) {
+							return false;
+						}
+					};
+					// If we got this far, everything in the call is safe, so skip to the next statement.
+					$newPtr = $this->next_non_empty( $param['end'] + 1 );
+					continue;
 				} elseif ( $this->is_wpdb_method_call( $newPtr, [ 'prepare' => true ] ) ) {
 					// It's a call to $wpdb->prepare(), safe.
 					return true;
@@ -393,6 +414,13 @@ class DirectDBSniff extends Sniff {
 				// then we can fail at this point.
 				if ( '$wpdb' !== $this->tokens[ $newPtr ][ 'content' ] && !$this->is_sanitized_var( $newPtr ) ) {
 					$this->unsafe_expression = $this->tokens[ $newPtr ][ 'content' ];
+					$var = $this->get_complex_variable( $newPtr );
+					if ( $var ) {
+						$this->unsafe_expression = $var[0];
+						if ( !empty( $var[1] ) ) {
+							$this->unsafe_expression .= '[' . implode( '][', $var[1] ) . ']';
+						}
+					}
 					return false;
 				}
 			} elseif ( in_array( $this->tokens[ $newPtr ][ 'code' ], Tokens::$castTokens ) ) {

--- a/MinimalPluginStandard/Sniffs/DirectDBSniff.php
+++ b/MinimalPluginStandard/Sniffs/DirectDBSniff.php
@@ -416,7 +416,7 @@ class DirectDBSniff extends Sniff {
 					$this->unsafe_expression = $this->tokens[ $newPtr ][ 'content' ];
 					$var = $this->get_complex_variable( $newPtr );
 					if ( $var ) {
-						$this->unsafe_expression = $var[0];
+						$this->unsafe_expression = '$' . $var[0];
 						if ( !empty( $var[1] ) ) {
 							$this->unsafe_expression .= '[' . implode( '][', $var[1] ) . ']';
 						}

--- a/MinimalPluginStandard/Sniffs/DirectDBSniff.php
+++ b/MinimalPluginStandard/Sniffs/DirectDBSniff.php
@@ -79,7 +79,7 @@ class DirectDBSniff extends Sniff {
 	 */
 	protected $warn_only_parameters = array(
 		'table',
-		#'this', // typically something like $this->tablename
+		'this', // typically something like $this->tablename
 	);
 
 	/**
@@ -475,7 +475,7 @@ class DirectDBSniff extends Sniff {
 	}
 
 	public function is_warning_parameter( $parameter_name ) {
-		return in_array( ltrim( $parameter_name, '$' ), $this->warn_only_parameters );
+		return in_array( ltrim( $parameter_name, '{$' ), $this->warn_only_parameters );
 	}
 
 	public function is_warning_sql( $sql ) {

--- a/MinimalPluginStandard/Sniffs/DirectDBSniff.php
+++ b/MinimalPluginStandard/Sniffs/DirectDBSniff.php
@@ -475,7 +475,12 @@ class DirectDBSniff extends Sniff {
 	}
 
 	public function is_warning_parameter( $parameter_name ) {
-		return in_array( ltrim( $parameter_name, '{$' ), $this->warn_only_parameters );
+		foreach ( $this->warn_only_parameters as $warn_param ) {
+			if ( preg_match( '/^[${]*' . preg_quote( $warn_param ) . '(?:\b|$)/', $parameter_name ) ) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	public function is_warning_sql( $sql ) {

--- a/MinimalPluginStandard/ruleset.xml
+++ b/MinimalPluginStandard/ruleset.xml
@@ -82,7 +82,9 @@
 	<!-- No PHP short open tags allowed. -->
 	<!-- Covers: https://github.com/Otto42/theme-check/blob/master/checks/phpshort.php -->
   
-	<rule ref="Generic.PHP.DisallowShortOpenTag"/>
+	<rule ref="Generic.PHP.DisallowShortOpenTag">
+		<type>warning</type>
+	</rule>
  
 
 	<!-- Alternative PHP open tags not allowed. -->
@@ -155,7 +157,9 @@
 
 	<!-- Check for use of deprecated WordPress classes, functions and function parameters. -->
 	<rule ref="WordPress.WP.DeprecatedClasses"/>
-	<rule ref="WordPress.WP.DeprecatedFunctions"/>
+	<rule ref="WordPress.WP.DeprecatedFunctions">
+		<type>warning</type>
+	</rule>
 	<rule ref="WordPress.WP.DeprecatedParameters"/>
 
 	<!-- Check for deprecated WordPress constants. -->

--- a/MinimalPluginStandard/ruleset.xml
+++ b/MinimalPluginStandard/ruleset.xml
@@ -161,7 +161,9 @@
 	<rule ref="WordPress.WP.DeprecatedFunctions">
 		<type>warning</type>
 	</rule>
-	<rule ref="WordPress.WP.DeprecatedParameters"/>
+	<rule ref="WordPress.WP.DeprecatedParameters">
+		<type>warning</type>
+	</rule>
 
 	<!-- Check for deprecated WordPress constants. -->
 	<rule ref="WordPress.WP.DiscouragedConstants">

--- a/MinimalPluginStandard/ruleset.xml
+++ b/MinimalPluginStandard/ruleset.xml
@@ -167,7 +167,7 @@
 
 	<!-- Check for deprecated WordPress constants. -->
 	<rule ref="WordPress.WP.DiscouragedConstants">
-		<type>error</type>
+		<type>warning</type>
 	</rule>
 
 	<!-- Check for usage of deprecated parameter values in WP functions and provide alternative based on the parameter passed. -->

--- a/MinimalPluginStandard/ruleset.xml
+++ b/MinimalPluginStandard/ruleset.xml
@@ -53,6 +53,7 @@
         <exclude name="WordPress.DB.PreparedSQLPlaceholders.UnnecessaryPrepare"/>
         <exclude name="WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare"/>
         <exclude name="WordPress.DB.PreparedSQLPlaceholders.MissingReplacements"/>
+		<type>warning</type>
     </rule>
 
     <!-- alex: needs refining eg on nonce checks

--- a/tests/db/DirectDBUnitTest.php
+++ b/tests/db/DirectDBUnitTest.php
@@ -33,7 +33,8 @@ class DisallowExtractSniffTest extends TestCase {
                 106,
                 113,
                 120,
-                140
+                140,
+                159
             ], 
             $error_lines );
 

--- a/tests/db/DirectDBUnitTest.php
+++ b/tests/db/DirectDBUnitTest.php
@@ -42,6 +42,7 @@ class DisallowExtractSniffTest extends TestCase {
         $this->assertEquals(
             [
                 89,
+                149,
             ],
             $warning_lines );
 

--- a/tests/db/DirectDBUnitTest.php-bad.inc
+++ b/tests/db/DirectDBUnitTest.php-bad.inc
@@ -148,3 +148,13 @@ function insecure_wpdb_query_14() {
 
 	$wpdb->get_results( "SELECT * FROM {$this->getPrefix()}_table WHERE 1=1 LIMIT 1" ); // unsafe but a warning rather than an error
 }
+
+function insecure_wpdb_query_15( $foo ) {
+	global $wpdb;
+
+	$bar = array(
+		$foo
+	);
+
+	$wpdb->get_results( "SELECT * FROM $wpdb->posts WHERE ID IN ('" . implode( "', '", $bar ) . "') LIMIT 1" ); // unsafe
+}

--- a/tests/db/DirectDBUnitTest.php-bad.inc
+++ b/tests/db/DirectDBUnitTest.php-bad.inc
@@ -142,3 +142,9 @@ function insecure_wpdb_query_14() {
 
 	}
 }
+
+function insecure_wpdb_query_14() {
+	global $wpdb;
+
+	$wpdb->get_results( "SELECT * FROM {$this->getPrefix()}_table WHERE 1=1 LIMIT 1" ); // unsafe but a warning rather than an error
+}

--- a/tests/db/DirectDBUnitTest.php-safe.inc
+++ b/tests/db/DirectDBUnitTest.php-safe.inc
@@ -165,3 +165,31 @@ function false_positive_7() {
 	// A bug in handling $wpdb->prepare() with multiple args?
 	$wpdb->query( $wpdb->prepare("UPDATE {$wpdb->posts} SET post_content = REPLACE(post_content, %s, %s)", $from_url, $to_url) ); // safe
 }
+
+function false_positive_8() {
+	global $wpdb;
+	$mysql_vars = array(
+			'key_buffer_size'    => true,   // Key cache size limit.
+			'max_allowed_packet' => false,  // Individual query size limit.
+			'max_connections'    => false,  // Max number of client connections.
+			'query_cache_limit'  => true,   // Individual query cache size limit.
+			'query_cache_size'   => true,   // Total cache size limit.
+			'query_cache_type'   => 'ON',   // Query cache on or off.
+	);
+	$extra_info = array();
+	$variables  = $wpdb->get_results( "SHOW VARIABLES WHERE Variable_name IN ( '" . implode( "', '", array_keys( $mysql_vars ) ) . "' )" ); // db call ok; no-cache ok.
+
+}
+
+function secure_wpdb_query_12( $foo ) {
+	global $wpdb;
+
+	$bar = array(
+		$foo
+	);
+
+	// Just like insecure_wpdb_query_15, except we'll escape $bar to make it safe enough
+	$bar = esc_sql( $bar );
+
+	$wpdb->get_results( "SELECT * FROM $wpdb->posts WHERE ID IN ('" . implode( "', '", $bar ) . "') LIMIT 1" ); // safe
+}

--- a/tests/db/DirectDBUnitTest.php-safe.inc
+++ b/tests/db/DirectDBUnitTest.php-safe.inc
@@ -193,3 +193,10 @@ function secure_wpdb_query_12( $foo ) {
 
 	$wpdb->get_results( "SELECT * FROM $wpdb->posts WHERE ID IN ('" . implode( "', '", $bar ) . "') LIMIT 1" ); // safe
 }
+
+function false_positive_9() {
+	global $wpdb;
+
+	$where_statement = implode( ', ', array_map( 'esc_sql', $default_ids ) );
+	$wpdb->query( "DELETE FROM {$wpdb->some_table} WHERE ID IN ({$where_statement})" ); // safe
+}


### PR DESCRIPTION
Reports are sometimes quite noisy. This PR is work in progress to reduce that. In general:

Errors should be reserved for things that definitely need human attention, like security risks and things that might break a production site.

Warnings are for things that should be called out but are not serious enough to require immediate attention, such as deprecations.