### PR TITLE
Fix/missed positives in prepare

### DIFF
--- a/tests/db/DirectDBUnitTest.php
+++ b/tests/db/DirectDBUnitTest.php
@@ -34,7 +34,8 @@ class DisallowExtractSniffTest extends TestCase {
                 113,
                 120,
                 140,
-                159
+                159,
+                168
             ], 
             $error_lines );
 

--- a/tests/db/DirectDBUnitTest.php
+++ b/tests/db/DirectDBUnitTest.php
@@ -33,7 +33,8 @@ class DisallowExtractSniffTest extends TestCase {
                 106,
                 113,
                 120,
-                140
+                140,
+                152
             ], 
             $error_lines );
 

--- a/tests/db/DirectDBUnitTest.php-bad.inc
+++ b/tests/db/DirectDBUnitTest.php-bad.inc
@@ -142,3 +142,12 @@ function insecure_wpdb_query_14() {
 
 	}
 }
+
+function insecure_wpdb_query_15( $foo ) {
+	global $wpdb;
+
+	$bar = $_POST['bad'];
+
+	// $foo is correctly escaped here, but variables in the left hand side of a prepare() are unsafe!
+	$wpdb->query( $wpdb->prepare( "SELECT * FROM $wpdb->users WHERE bar='$bar' AND foo=%s", $foo  ) ); // unsafe
+}

--- a/tests/db/DirectDBUnitTest.php-bad.inc
+++ b/tests/db/DirectDBUnitTest.php-bad.inc
@@ -158,3 +158,12 @@ function insecure_wpdb_query_15( $foo ) {
 
 	$wpdb->get_results( "SELECT * FROM $wpdb->posts WHERE ID IN ('" . implode( "', '", $bar ) . "') LIMIT 1" ); // unsafe
 }
+
+function insecure_wpdb_query_16( $foo ) {
+	global $wpdb;
+
+	$bar = $_POST['bad'];
+
+	// $foo is correctly escaped here, but variables in the left hand side of a prepare() are unsafe!
+	$wpdb->query( $wpdb->prepare( "SELECT * FROM $wpdb->users WHERE bar='$bar' AND foo=%s", $foo  ) ); // unsafe
+}


### PR DESCRIPTION
This aims to fix missed positives in prepare() statements, as demonstrated in `insecure_wpdb_query_16`.