### PR TITLE
Fix false positives in second param to get_row() and friends

### DIFF
--- a/MinimalPluginStandard/Sniffs/DirectDBSniff.php
+++ b/MinimalPluginStandard/Sniffs/DirectDBSniff.php
@@ -77,7 +77,7 @@ class DirectDBSniff extends Sniff {
 	);
 
 	/**
-	 * $wpdb methods that require escaped
+	 * $wpdb methods that require the first parameter to be escaped.
 	 *
 	 * @var array[]
 	 */
@@ -735,53 +735,51 @@ class DirectDBSniff extends Sniff {
 
 		// If we're in a call to an unsafe db method like $wpdb->query then check all the parameters for safety
 		if ( isset( $this->unsafe_methods[ $method ] ) ) {
-			foreach ( PassedParameters::getParameters( $this->phpcsFile, $methodPtr ) as $methodParam ) {
-				// If the expression wasn't escaped safely, then alert.
-				if ( !$this->expression_is_safe( $methodParam[ 'start' ], $methodParam[ 'end' ] + 1 ) ) {
-					if ( $this->unsafe_expression ) {
-						if ( $this->is_warning_parameter( $this->unsafe_expression ) || $this->is_warning_sql( $methodParam[ 'clean' ] ) || $this->is_suppressed_line( $methodPtr ) ) {
-							$this->phpcsFile->addWarning( 'Unescaped parameter %s used in $wpdb->%s(%s)',
-								$methodPtr,
-								'UnescapedDBParameter',
-								[ $this->unsafe_expression, $method, $methodParam[ 'clean' ] ],
-								0,
-								false
-							);
-						} else {
-							$this->phpcsFile->addError( 'Unescaped parameter %s used in $wpdb->%s(%s)',
+			// Only the first parameter needs escaping
+			$methodParam = reset( PassedParameters::getParameters( $this->phpcsFile, $methodPtr ) );
+			// If the expression wasn't escaped safely, then alert.
+			if ( !$this->expression_is_safe( $methodParam[ 'start' ], $methodParam[ 'end' ] + 1 ) ) {
+				if ( $this->unsafe_expression ) {
+					if ( $this->is_warning_parameter( $this->unsafe_expression ) || $this->is_warning_sql( $methodParam[ 'clean' ] ) || $this->is_suppressed_line( $methodPtr ) ) {
+						$this->phpcsFile->addWarning( 'Unescaped parameter %s used in $wpdb->%s(%s)',
 							$methodPtr,
 							'UnescapedDBParameter',
 							[ $this->unsafe_expression, $method, $methodParam[ 'clean' ] ],
 							0,
 							false
 						);
-
-						}
 					} else {
-						if ( $this->is_warning_parameter( $methodParam[ 'clean' ] ) || $this->is_warning_sql( $methodParam[ 'clean' ] ) || $this->is_suppressed_line( $methodPtr ) ) {
-							$this->phpcsFile->addWarning( 'Unescaped parameter %s used in $wpdb->%s',
-								$methodPtr,
-								'UnescapedDBParameter',
-								[ $methodParam[ 'clean' ], $method ],
-								0,
-								false
-							);
-						} else {
-							$this->phpcsFile->addError( 'Unescaped parameter %s used in $wpdb->%s',
-								$methodPtr,
-								'UnescapedDBParameter',
-								[ $methodParam[ 'clean' ], $method ],
-								0,
-								false
-							);
-						}
-					}
-					return; // Only need to error on the first occurrence
-				}
+						$this->phpcsFile->addError( 'Unescaped parameter %s used in $wpdb->%s(%s)',
+						$methodPtr,
+						'UnescapedDBParameter',
+						[ $this->unsafe_expression, $method, $methodParam[ 'clean' ] ],
+						0,
+						false
+					);
 
+					}
+				} else {
+					if ( $this->is_warning_parameter( $methodParam[ 'clean' ] ) || $this->is_warning_sql( $methodParam[ 'clean' ] ) || $this->is_suppressed_line( $methodPtr ) ) {
+						$this->phpcsFile->addWarning( 'Unescaped parameter %s used in $wpdb->%s',
+							$methodPtr,
+							'UnescapedDBParameter',
+							[ $methodParam[ 'clean' ], $method ],
+							0,
+							false
+						);
+					} else {
+						$this->phpcsFile->addError( 'Unescaped parameter %s used in $wpdb->%s',
+							$methodPtr,
+							'UnescapedDBParameter',
+							[ $methodParam[ 'clean' ], $method ],
+							0,
+							false
+						);
+					}
+				}
+				return; // Only need to error on the first occurrence
 			}
 		}
-
 	}
 
 }

--- a/tests/db/DirectDBUnitTest.php-safe.inc
+++ b/tests/db/DirectDBUnitTest.php-safe.inc
@@ -272,3 +272,19 @@ function secure_wpdb_query_15() {
 
 		$id = $wpdb->get_var( $query );
 }
+
+function false_positive_12( $tax_rate_id, $output_type = ARRAY_A ) {
+	global $wpdb;
+
+	return $wpdb->get_row(
+		$wpdb->prepare(
+			"
+				SELECT *
+				FROM {$wpdb->prefix}woocommerce_tax_rates
+				WHERE tax_rate_id = %d
+			",
+			$tax_rate_id
+		),
+		$output_type
+	);
+}


### PR DESCRIPTION
Only the first parameter to most DB query functions needs to be escaped. Other values are safe. 