### PR TITLE
Unwind assignments to provide additional context about unescaped variables

### DIFF
--- a/MinimalPluginStandard/Sniffs/DirectDBSniff.php
+++ b/MinimalPluginStandard/Sniffs/DirectDBSniff.php
@@ -597,7 +597,7 @@ class DirectDBSniff extends Sniff {
 				}
 
 				// Where are we?
-				$context = $this->get_context( $newPtr );
+				$context = $this->get_context( $stackPtr );
 
 				// If we've found an unsanitized var then fail early
 				if ( ! $this->_is_sanitized_var( $var, $context ) ) {

--- a/MinimalPluginStandard/Sniffs/DirectDBSniff.php
+++ b/MinimalPluginStandard/Sniffs/DirectDBSniff.php
@@ -380,7 +380,7 @@ class DirectDBSniff extends Sniff {
 
 	protected function get_expression_as_string( $stackPtr ) {
 		$end = $this->phpcsFile->findEndOfStatement( $stackPtr );
-		return $this->phpcsFile->getTokensAsString( $stackPtr, $end - $stackPtr );
+		return $this->phpcsFile->getTokensAsString( $stackPtr, $end - $stackPtr + 1 );
 	}
 
 	protected function get_variable_as_string( $stackPtr ) {
@@ -600,7 +600,7 @@ class DirectDBSniff extends Sniff {
 				$context = $this->get_context( $newPtr );
 
 				// If we've found an unsanitized var then fail early
-				if ( ! $this->_is_sanitized_var( $var, $context ) ) {			
+				if ( ! $this->_is_sanitized_var( $var, $context ) ) {
 					return $var;
 				}
 			}

--- a/MinimalPluginStandard/Sniffs/DirectDBSniff.php
+++ b/MinimalPluginStandard/Sniffs/DirectDBSniff.php
@@ -996,46 +996,26 @@ class DirectDBSniff extends Sniff {
 			$methodParam = reset( PassedParameters::getParameters( $this->phpcsFile, $methodPtr ) );
 			// If the expression wasn't escaped safely, then alert.
 			if ( $unsafe_ptr = $this->check_expression( $methodParam[ 'start' ], $methodParam[ 'end' ] + 1 ) ) {
-					$extra_context = $this->unwind_unsafe_assignments( $unsafe_ptr );
-					$unsafe_expression = $this->get_unsafe_expression_as_string( $unsafe_ptr );
+				$extra_context = $this->unwind_unsafe_assignments( $unsafe_ptr );
+				$unsafe_expression = $this->get_unsafe_expression_as_string( $unsafe_ptr );
 
-					if ( $this->is_warning_parameter( $unsafe_expression ) || $this->is_warning_sql( $methodParam[ 'clean' ] ) || $this->is_suppressed_line( $methodPtr ) ) {
-						$this->phpcsFile->addWarning( 'Unescaped parameter %s used in $wpdb->%s(%s)%s',
-							$methodPtr,
-							'UnescapedDBParameter',
-							[ $unsafe_expression, $method, $methodParam[ 'clean' ], rtrim( "\n" . join( "\n", $extra_context ) ) ],
-							0,
-							false
-						);
-					} else {
-						$this->phpcsFile->addError( 'Unescaped parameter %s used in $wpdb->%s(%s)%s',
+				if ( $this->is_warning_parameter( $unsafe_expression ) || $this->is_warning_sql( $methodParam[ 'clean' ] ) || $this->is_suppressed_line( $methodPtr ) ) {
+					$this->phpcsFile->addWarning( 'Unescaped parameter %s used in $wpdb->%s(%s)%s',
 						$methodPtr,
 						'UnescapedDBParameter',
 						[ $unsafe_expression, $method, $methodParam[ 'clean' ], rtrim( "\n" . join( "\n", $extra_context ) ) ],
 						0,
 						false
 					);
-
-					}
-/*				} else {
-					if ( $this->is_warning_parameter( $methodParam[ 'clean' ] ) || $this->is_warning_sql( $methodParam[ 'clean' ] ) || $this->is_suppressed_line( $methodPtr ) ) {
-						$this->phpcsFile->addWarning( 'Unescaped parameter %s used in $wpdb->%s',
-							$methodPtr,
-							'UnescapedDBParameter',
-							[ $methodParam[ 'clean' ], $method ],
-							0,
-							false
-						);
-					} else {
-						$this->phpcsFile->addError( 'Unescaped parameter %s used in $wpdb->%s',
-							$methodPtr,
-							'UnescapedDBParameter',
-							[ $methodParam[ 'clean' ], $method ],
-							0,
-							false
-						);
-					}
-				} */
+				} else {
+					$this->phpcsFile->addError( 'Unescaped parameter %s used in $wpdb->%s(%s)%s',
+						$methodPtr,
+						'UnescapedDBParameter',
+						[ $unsafe_expression, $method, $methodParam[ 'clean' ], rtrim( "\n" . join( "\n", $extra_context ) ) ],
+						0,
+						false
+					);
+				}
 				return; // Only need to error on the first occurrence
 			}
 		}

--- a/tests/db/DirectDBUnitTest.php
+++ b/tests/db/DirectDBUnitTest.php
@@ -46,7 +46,6 @@ class DisallowExtractSniffTest extends TestCase {
 			$error_lines );
 
 		$warning_lines = array_keys( $phpcsFile->getWarnings() );
-
 		$this->assertEquals(
 			[
 				89,
@@ -59,7 +58,8 @@ class DisallowExtractSniffTest extends TestCase {
 				278,
 				279,
 				280,
-				281
+				281,
+				301
 			],
 			$warning_lines );
 

--- a/tests/db/DirectDBUnitTest.php-bad.inc
+++ b/tests/db/DirectDBUnitTest.php-bad.inc
@@ -291,3 +291,14 @@ function insecure_do_not_use( $ids, $status ) {
 	$sql = "SELECT * FROM $wpdb->posts WHERE ID IN ($in)";
 	return $wpdb->get_results( $wpdb->prepare( $sql . " AND post_status = %s", $status ) );
 }
+
+class Example_Test_Class {
+	public static function insecure_wpdb_query_23() {
+		if ($purge_days > 30) {
+			$table_name = DB::table('visit');
+			$date_string = TimeZone::getCurrentDate('Y-m-d', '-' . $purge_days);
+
+			$result = $wpdb->query($wpdb->prepare("DELETE FROM {$table_name} WHERE `last_counter` < %s", $date_string)); // technically unsafe but a warning only
+		}
+	}
+}


### PR DESCRIPTION
This attempts to store and unwind the local variable stack, so as to provide extra info about how and why a query was determined to have unescaped parameters. For example:

```
FILE: .../action-scheduler/classes/abstracts/ActionScheduler_Abstract_ListTable.php
--------------------------------------------------------------------------------
FOUND 2 ERRORS AFFECTING 2 LINES
--------------------------------------------------------------------------------
 431 | ERROR | Unescaped parameter $sql used in $wpdb->get_results($sql)
     |       | $sql assigned unsafely at line 429:
     |       |  $sql = "SELECT $columns FROM {$this->table_name} {$where}
     |       | {$order} {$limit} {$offset}"
     |       | $columns assigned unsafely at line 421:
     |       |  $columns = '`' . implode( '`, `', $this->get_table_columns() )
     |       | . '`'
     |       | $where assigned safely at line 426:
     |       |  $where = ''
     |       | $where assigned unsafely at line 424:
     |       |  $where = 'WHERE ('. implode( ') AND (', $where ) . ')'
     |       | $order assigned unsafely at line 416:
     |       |  $order   = $this->get_items_query_order()
     |       | $limit assigned unsafely at line 414:
     |       |  $limit   = $this->get_items_query_limit()
     |       | $offset assigned unsafely at line 415:
     |       |  $offset  = $this->get_items_query_offset()
     |       | (WordPressDotOrg.sniffs.DirectDB.UnescapedDBParameter)
 434 | ERROR | Unescaped parameter  used in $wpdb->get_var($query_count)
     |       | $query_count assigned unsafely at line 433:
     |       |  $query_count = "SELECT COUNT({$this->ID}) FROM
     |       | {$this->table_name} {$where}"
     |       | $where assigned safely at line 426:
     |       |  $where = ''
     |       | $where assigned unsafely at line 424:
     |       |  $where = 'WHERE ('. implode( ') AND (', $where ) . ')'
     |       | (WordPressDotOrg.sniffs.DirectDB.UnescapedDBParameter)
--------------------------------------------------------------------------------
```