### PR TITLE
Add/verify nonce misuse

### DIFF
--- a/MinimalPluginStandard/Sniffs/VerifyNonceSniff.php
+++ b/MinimalPluginStandard/Sniffs/VerifyNonceSniff.php
@@ -213,6 +213,16 @@ class VerifyNonceSniff extends Sniff {
 					}
 				}
 
+			} else {
+				// wp_verify_nonce() used as an unconditional statement - most likely mistaken for check_admin_referer()
+				$this->phpcsFile->addError( 'Unconditional call to wp_verify_nonce().',
+				$stackPtr,
+				'UnsafeVerifyNonceStatement',
+				[],
+				0,
+				false
+			);
+
 			}
 
 

--- a/MinimalPluginStandard/Sniffs/VerifyNonceSniff.php
+++ b/MinimalPluginStandard/Sniffs/VerifyNonceSniff.php
@@ -100,13 +100,14 @@ class VerifyNonceSniff extends Sniff {
 	 */
 	protected function scope_contains_error_terminator( $start, $end ) {
 
-		$stackPtr = $this->phpcsFile->findNext( Tokens::$functionNameTokens, $start, $end, false, null, false );
+		$stackPtr = $this->phpcsFile->findNext( Tokens::$functionNameTokens + [ \T_RETURN => \T_RETURN ], $start, $end, false, null, false );
 		while ( $stackPtr <= $end && $stackPtr ) {
-			var_dump( $this->tokens[ $stackPtr ][ 'content' ] );
 			if ( in_array( $this->tokens[ $stackPtr ][ 'content' ], array(
 					'exit',
 					'die',
 					'wp_send_json_error',
+					'wp_nonce_ays',
+					'return',
 				) ) ) {
 					return $stackPtr;
 			}

--- a/MinimalPluginStandard/Sniffs/VerifyNonceSniff.php
+++ b/MinimalPluginStandard/Sniffs/VerifyNonceSniff.php
@@ -224,7 +224,7 @@ class VerifyNonceSniff extends Sniff {
 
 						// if ( $something || wp_verify_nonce( ... ) )
 						if ( $this->expression_contains_or( $expression_start, $expression_end ) && $this->scope_contains_error_terminator( $scope_start, $scope_end ) ) {
-							$this->phpcsFile->addError( 'Unsafe use of wp_verify_nonce() in expression %s.',
+							$this->phpcsFile->addError( 'Possibly unsafe use of wp_verify_nonce() in expression %s.',
 								$stackPtr,
 								'UnsafeVerifyNonceElse',
 								[ $this->tokens_as_string( $expression_start, $expression_end ) ], // [ $unsafe_expression, $method, $methodParam[ 'clean' ], rtrim( "\n" . join( "\n", $extra_context ) ) ],

--- a/MinimalPluginStandard/Sniffs/VerifyNonceSniff.php
+++ b/MinimalPluginStandard/Sniffs/VerifyNonceSniff.php
@@ -35,13 +35,8 @@ class VerifyNonceSniff extends Sniff {
 	protected function is_conditional_expression( $stackPtr ) {
 		if ( $this->tokens[ $stackPtr ][ 'nested_parenthesis' ] ) {
 			$start = array_key_last( $this->tokens[ $stackPtr ][ 'nested_parenthesis' ] );
-			#$end = $this->tokens[ $stackPtr ][ 'nested_parenthesis' ][ $start ];
 			$ownerPtr = $this->tokens[ $start ][ 'parenthesis_owner' ];
 			if ( in_array( $this->tokens[ $ownerPtr ][ 'code' ], [ \T_IF, \T_ELSEIF ] ) ) {
-				#var_dump( 'scope_opener', $this->tokens[ $this->tokens[ $ownerPtr ][ 'scope_opener' ] ] );
-				#var_dump( $ownerPtr, $this->tokens[ $ownerPtr ] );
-				#var_dump( 'parens', $this->tokens_as_string( $this->tokens[ $ownerPtr ][ 'parenthesis_opener' ], $this->tokens[ $ownerPtr ][ 'parenthesis_closer' ] ) );
-				#var_dump( 'scope', $this->tokens_as_string( $this->tokens[ $ownerPtr ][ 'scope_opener' ], $this->tokens[ $ownerPtr ][ 'scope_closer' ] ) );
 				return $ownerPtr;
 			}
 		}
@@ -55,8 +50,6 @@ class VerifyNonceSniff extends Sniff {
 	protected function get_expression_from_condition( $stackPtr ) {
 		if ( isset( $this->tokens[ $stackPtr ][ 'parenthesis_opener' ] ) ) {
 			return [ $this->tokens[ $stackPtr ][ 'parenthesis_opener' ], $this->tokens[ $stackPtr ][ 'parenthesis_closer' ] ];
-		} else {
-			var_dump( "no expression", $this->tokens[ $stackPtr ] );
 		}
 		return false;
 	}
@@ -87,7 +80,6 @@ class VerifyNonceSniff extends Sniff {
 	protected function has_else( $stackPtr ) {
 		if ( $this->tokens[ $stackPtr ][ 'scope_closer' ] ) {
 			$nextPtr = $this->next_non_empty( $this->tokens[ $stackPtr ][ 'scope_closer' ] + 1 );
-			#var_dump( __FUNCTION__,  $stackPtr, $this->tokens[ $stackPtr ], $nextPtr, $this->tokens[ $nextPtr ] );
 			if ( $nextPtr && in_array( $this->tokens[ $nextPtr ][ 'code' ], [ \T_ELSE, \T_ELSEIF ] ) ) {
 				return $nextPtr;
 			}
@@ -127,7 +119,6 @@ class VerifyNonceSniff extends Sniff {
 			\T_LOGICAL_AND => \T_LOGICAL_AND,
 			
 		];
-		#var_dump( __FUNCTION__, $this->phpcsFile->getTokensAsString( $start, $end - $start + 1 ) );
 		return $this->phpcsFile->findNext( $tokens, $start, $end, false, null, false );
 	}
 
@@ -162,23 +153,16 @@ class VerifyNonceSniff extends Sniff {
 	 */
 	public function process_token( $stackPtr ) {
 		if ( 'wp_verify_nonce' === $this->tokens[ $stackPtr ][ 'content' ] ) {
-			#var_dump( $this->tokens[ $stackPtr ] );
-			#foreach ( $this->tokens[ $stackPtr ][ 'nested_parenthesis' ] as $a => $b ) {
-			#	var_dump( 'nested', $this->tokens[ $a ], $this->tokens[ $b ] );
-			#}
 			if ( $ifPtr = $this->is_conditional_expression( $stackPtr ) ) {
 				// We're in a conditional, something like if ( wp_verify_nonce() )
 
 				if ( $this->expression_is_negated( $stackPtr ) ) {
 					// if ( !wp_verify_nonce() )
-					var_dump( "negated wp_verify_nonce" );
 
 					list( $expression_start, $expression_end ) = $this->get_expression_from_condition( $ifPtr );
 					list( $scope_start, $scope_end ) = $this->get_scope_from_condition( $ifPtr );
-					var_dump( "checking negated", $this->tokens_as_string( $expression_start, $expression_end ), $this->tokens_as_string( $scope_start, $scope_end ) );
 
 					if ( $this->expression_contains_and( $expression_start, $expression_end ) && $this->scope_contains_error_terminator( $scope_start, $scope_end ) ) {
-						var_dump( "error in", $this->tokens_as_string( $scope_start, $scope_end ) );
 						$this->phpcsFile->addError( 'Unsafe use of wp_verify_nonce() in expression %s.',
 							$stackPtr,
 							'UnsafeVerifyNonceNegatedAnd',
@@ -193,7 +177,6 @@ class VerifyNonceSniff extends Sniff {
 					// In this case we want the else {} part
 					$elsePtr = $this->has_else( $ifPtr );
 					if ( $elsePtr ) {
-						var_dump( "else", $this->tokens[ $elsePtr ] );
 						list( $expression_start, $expression_end ) = $this->get_expression_from_condition( $ifPtr );
 						list( $scope_start, $scope_end ) = $this->get_scope_from_condition( $elsePtr );
 

--- a/MinimalPluginStandard/Sniffs/VerifyNonceSniff.php
+++ b/MinimalPluginStandard/Sniffs/VerifyNonceSniff.php
@@ -34,10 +34,11 @@ class VerifyNonceSniff extends Sniff {
 	 */
 	protected function is_conditional_expression( $stackPtr ) {
 		if ( $this->tokens[ $stackPtr ][ 'nested_parenthesis' ] ) {
-			$start = array_key_last( $this->tokens[ $stackPtr ][ 'nested_parenthesis' ] );
-			$ownerPtr = $this->tokens[ $start ][ 'parenthesis_owner' ];
-			if ( in_array( $this->tokens[ $ownerPtr ][ 'code' ], [ \T_IF, \T_ELSEIF ] ) ) {
-				return $ownerPtr;
+			foreach ( array_reverse( $this->tokens[ $stackPtr ][ 'nested_parenthesis' ], true ) as $start => $end ) {
+				$ownerPtr = $this->tokens[ $start ][ 'parenthesis_owner' ];
+				if ( in_array( $this->tokens[ $ownerPtr ][ 'code' ], [ \T_IF, \T_ELSEIF ] ) ) {
+					return $ownerPtr;
+				}
 			}
 		}
 

--- a/MinimalPluginStandard/Sniffs/VerifyNonceSniff.php
+++ b/MinimalPluginStandard/Sniffs/VerifyNonceSniff.php
@@ -104,7 +104,11 @@ class VerifyNonceSniff extends Sniff {
 	 */
 	protected function scope_contains_error_terminator( $start, $end ) {
 
-		$stackPtr = $this->phpcsFile->findNext( Tokens::$functionNameTokens + [ \T_RETURN => \T_RETURN ], $start, $end, false, null, false );
+		$tokens_to_search =
+			Tokens::$functionNameTokens +
+			[ \T_RETURN => \T_RETURN ];
+
+		$stackPtr = $this->phpcsFile->findNext( $tokens_to_search, $start, $end, false, null, false );
 		while ( $stackPtr <= $end && $stackPtr ) {
 			if ( in_array( $this->tokens[ $stackPtr ][ 'content' ], array(
 					'exit',
@@ -116,7 +120,7 @@ class VerifyNonceSniff extends Sniff {
 					return $stackPtr;
 			}
 
-			$stackPtr = $this->phpcsFile->findNext( Tokens::$functionNameTokens, $stackPtr + 1, $end, false, null, false );
+			$stackPtr = $this->phpcsFile->findNext( $tokens_to_search, $stackPtr + 1, $end, false, null, false );
 		}
 
 		return false;

--- a/MinimalPluginStandard/Sniffs/VerifyNonceSniff.php
+++ b/MinimalPluginStandard/Sniffs/VerifyNonceSniff.php
@@ -196,9 +196,9 @@ class VerifyNonceSniff extends Sniff {
 						var_dump( "else", $this->tokens[ $elsePtr ] );
 						list( $expression_start, $expression_end ) = $this->get_expression_from_condition( $ifPtr );
 						list( $scope_start, $scope_end ) = $this->get_scope_from_condition( $elsePtr );
-						#var_dump( "checking else", $this->tokens_as_string( $expression_start, $expression_end ), $this->tokens_as_string( $scope_start, $scope_end ) );
 
-						if ( $this->expression_contains_and( $expression_start, $expression_end ) && $this->scope_contains_error_terminator( $scope_start, $scope_end ) ) {
+						// In this case it doesn't matter if there's a logical AND, but the else clause must contain a terminator.
+						if ( ! $this->scope_contains_error_terminator( $scope_start, $scope_end ) ) {
 							var_dump( "error in", $this->tokens_as_string( $scope_start, $scope_end ) );
 							$this->phpcsFile->addError( 'Unsafe use of wp_verify_nonce() in expression %s.',
 								$stackPtr,

--- a/MinimalPluginStandard/Sniffs/VerifyNonceSniff.php
+++ b/MinimalPluginStandard/Sniffs/VerifyNonceSniff.php
@@ -101,6 +101,14 @@ class VerifyNonceSniff extends Sniff {
 	}
 
 	/**
+	 * Is the expression part of an assignment?
+	 */
+	protected function is_assignment_statement( $stackPtr ) {
+		$start = $this->phpcsFile->findStartOfStatement( $stackPtr );
+		return $this->is_assignment( $start );
+	}
+
+	/**
 	 * Does the given scope contain an exit, die, wp_send_json_error(), or similar statement that's sufficient to handle a nonce failure?
 	 */
 	protected function scope_contains_error_terminator( $start, $end ) {
@@ -226,7 +234,7 @@ class VerifyNonceSniff extends Sniff {
 
 			} else {
 				
-				if ( !$this->is_return_statement( $stackPtr ) ) {
+				if ( !$this->is_return_statement( $stackPtr ) && !$this->is_assignment_statement( $stackPtr ) ) {
 					// wp_verify_nonce() used as an unconditional statement - most likely mistaken for check_admin_referer()
 					$this->phpcsFile->addError( 'Unconditional call to wp_verify_nonce().',
 					$stackPtr,

--- a/MinimalPluginStandard/Sniffs/VerifyNonceSniff.php
+++ b/MinimalPluginStandard/Sniffs/VerifyNonceSniff.php
@@ -240,7 +240,7 @@ class VerifyNonceSniff extends Sniff {
 				
 				if ( !$this->is_return_statement( $stackPtr ) && !$this->is_assignment_statement( $stackPtr ) ) {
 					// wp_verify_nonce() used as an unconditional statement - most likely mistaken for check_admin_referer()
-					$this->phpcsFile->addError( 'Unconditional call to wp_verify_nonce().',
+					$this->phpcsFile->addError( 'Unconditional call to wp_verify_nonce(). Consider using check_admin_referer() instead.',
 					$stackPtr,
 					'UnsafeVerifyNonceStatement',
 					[],

--- a/MinimalPluginStandard/Sniffs/VerifyNonceSniff.php
+++ b/MinimalPluginStandard/Sniffs/VerifyNonceSniff.php
@@ -1,0 +1,221 @@
+<?php
+
+namespace WordPressDotOrg\Code_Analysis\sniffs;
+
+use WordPressCS\WordPress\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+use PHP_CodeSniffer\Util\Variables;
+use PHPCSUtils\Utils\PassedParameters;
+
+require_once( dirname( dirname( __DIR__ ) ) . '/vendor/autoload.php' );
+
+/**
+ * Check for buggy/insecure use of wp_verify_nonce()
+ */
+class VerifyNonceSniff extends Sniff {
+
+	/**
+	 * Helper function to return the next non-empty token starting at $stackPtr inclusive.
+	 */
+	protected function next_non_empty( $stackPtr, $local_only = true ) {
+		return $this->phpcsFile->findNext( Tokens::$emptyTokens, $stackPtr , null, true, null, $local_only );
+	}
+
+	protected function previous_non_empty( $stackPtr, $local_only = true ) {
+		return $this->phpcsFile->findPrevious( Tokens::$emptyTokens, $stackPtr , null, true, null, $local_only );
+	}
+
+	protected function tokens_as_string( $start, $end ) {
+		return $this->phpcsFile->getTokensAsString( $start, $end - $start + 1 );
+	}
+
+	/**
+	 * Is $stackPtr part of the conditional expression in an `if` statement?
+	 */
+	protected function is_conditional_expression( $stackPtr ) {
+		if ( $this->tokens[ $stackPtr ][ 'nested_parenthesis' ] ) {
+			$start = array_key_last( $this->tokens[ $stackPtr ][ 'nested_parenthesis' ] );
+			#$end = $this->tokens[ $stackPtr ][ 'nested_parenthesis' ][ $start ];
+			$ownerPtr = $this->tokens[ $start ][ 'parenthesis_owner' ];
+			if ( in_array( $this->tokens[ $ownerPtr ][ 'code' ], [ \T_IF, \T_ELSEIF ] ) ) {
+				#var_dump( 'scope_opener', $this->tokens[ $this->tokens[ $ownerPtr ][ 'scope_opener' ] ] );
+				#var_dump( $ownerPtr, $this->tokens[ $ownerPtr ] );
+				#var_dump( 'parens', $this->tokens_as_string( $this->tokens[ $ownerPtr ][ 'parenthesis_opener' ], $this->tokens[ $ownerPtr ][ 'parenthesis_closer' ] ) );
+				#var_dump( 'scope', $this->tokens_as_string( $this->tokens[ $ownerPtr ][ 'scope_opener' ], $this->tokens[ $ownerPtr ][ 'scope_closer' ] ) );
+				return $ownerPtr;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Get the conditional expression part of an if/elseif statement.
+	 */
+	protected function get_expression_from_condition( $stackPtr ) {
+		if ( isset( $this->tokens[ $stackPtr ][ 'parenthesis_opener' ] ) ) {
+			return [ $this->tokens[ $stackPtr ][ 'parenthesis_opener' ], $this->tokens[ $stackPtr ][ 'parenthesis_closer' ] ];
+		} else {
+			var_dump( "no expression", $this->tokens[ $stackPtr ] );
+		}
+		return false;
+	}
+
+	/**
+	 * Get the scope part of an if/else/elseif statement.
+	 */
+	protected function get_scope_from_condition( $stackPtr ) {
+		if ( !in_array( $this->tokens[ $stackPtr ][ 'code' ], [ \T_IF, \T_ELSEIF, \T_ELSE ] ) ) {
+			return false;
+		}
+		if ( isset( $this->tokens[ $stackPtr ][ 'scope_opener' ] ) ) {
+			return [ $this->tokens[ $stackPtr ][ 'scope_opener' ], $this->tokens[ $stackPtr ][ 'scope_closer' ] ];
+		} else {
+			// if ( $foo ) bar();
+			$start = $this->next_non_empty( $stackPtr + 1 );
+			$end = $this->phpcsFile->findEndOfStatement( $start );
+			return [ $start, $end ];
+		}
+		return false;
+	}
+
+
+
+	/**
+	 * Does the given if statement have an 'else' or 'elseif' 
+	 */
+	protected function has_else( $stackPtr ) {
+		if ( $this->tokens[ $stackPtr ][ 'scope_closer' ] ) {
+			$nextPtr = $this->next_non_empty( $this->tokens[ $stackPtr ][ 'scope_closer' ] + 1 );
+			#var_dump( __FUNCTION__,  $stackPtr, $this->tokens[ $stackPtr ], $nextPtr, $this->tokens[ $nextPtr ] );
+			if ( $nextPtr && in_array( $this->tokens[ $nextPtr ][ 'code' ], [ \T_ELSE, \T_ELSEIF ] ) ) {
+				return $nextPtr;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Does the given scope contain an exit, die, wp_send_json_error(), or similar statement that's sufficient to handle a nonce failure?
+	 */
+	protected function scope_contains_error_terminator( $start, $end ) {
+
+		$stackPtr = $this->phpcsFile->findNext( Tokens::$functionNameTokens, $start, $end, false, null, false );
+		while ( $stackPtr <= $end && $stackPtr ) {
+			var_dump( $this->tokens[ $stackPtr ][ 'content' ] );
+			if ( in_array( $this->tokens[ $stackPtr ][ 'content' ], array(
+					'exit',
+					'die',
+					'wp_send_json_error',
+				) ) ) {
+					return $stackPtr;
+			}
+
+			$stackPtr = $this->phpcsFile->findNext( Tokens::$functionNameTokens, $stackPtr + 1, $end, false, null, false );
+		}
+
+		return false;
+	}
+
+	/**
+	 * Does the given expression contain multiple 'and' clauses like `$foo && bar()` or `foo() and $bar`?
+	 */
+	protected function expression_contains_and( $start, $end ) {
+		$tokens = [
+			\T_BOOLEAN_AND => \T_BOOLEAN_AND,
+			\T_LOGICAL_AND => \T_LOGICAL_AND,
+			
+		];
+		#var_dump( __FUNCTION__, $this->phpcsFile->getTokensAsString( $start, $end - $start + 1 ) );
+		return $this->phpcsFile->findNext( $tokens, $start, $end, false, null, false );
+	}
+
+	/**
+	 * Is the expression immediately preceded by a boolean not `!`?
+	 */
+	protected function expression_is_negated( $stackPtr ) {
+		$previous = $this->previous_non_empty( $stackPtr - 1 );
+		if ( \T_BOOLEAN_NOT === $this->tokens[ $previous ][ 'code' ] ) {
+			return $previous;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return Tokens::$functionNameTokens;
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return int|void Integer stack pointer to skip forward or void to continue
+	 *                  normal file processing.
+	 */
+	public function process_token( $stackPtr ) {
+		if ( 'wp_verify_nonce' === $this->tokens[ $stackPtr ][ 'content' ] ) {
+			#var_dump( $this->tokens[ $stackPtr ] );
+			#foreach ( $this->tokens[ $stackPtr ][ 'nested_parenthesis' ] as $a => $b ) {
+			#	var_dump( 'nested', $this->tokens[ $a ], $this->tokens[ $b ] );
+			#}
+			if ( $ifPtr = $this->is_conditional_expression( $stackPtr ) ) {
+				// We're in a conditional, something like if ( wp_verify_nonce() )
+
+				if ( $this->expression_is_negated( $stackPtr ) ) {
+					// if ( !wp_verify_nonce() )
+					var_dump( "negated wp_verify_nonce" );
+
+					list( $expression_start, $expression_end ) = $this->get_expression_from_condition( $ifPtr );
+					list( $scope_start, $scope_end ) = $this->get_scope_from_condition( $ifPtr );
+					var_dump( "checking negated", $this->tokens_as_string( $expression_start, $expression_end ), $this->tokens_as_string( $scope_start, $scope_end ) );
+
+					if ( $this->expression_contains_and( $expression_start, $expression_end ) && $this->scope_contains_error_terminator( $scope_start, $scope_end ) ) {
+						var_dump( "error in", $this->tokens_as_string( $scope_start, $scope_end ) );
+						$this->phpcsFile->addError( 'Unsafe use of wp_verify_nonce() in expression %s.',
+							$stackPtr,
+							'UnsafeVerifyNonceNegatedAnd',
+							[ $this->tokens_as_string( $expression_start, $expression_end ) ], //[ $unsafe_expression, $method, $methodParam[ 'clean' ], rtrim( "\n" . join( "\n", $extra_context ) ) ],
+							0,
+							false
+						);
+
+					}
+				} else {
+					// if ( wp_verify_nonce() )
+					// In this case we want the else {} part
+					$elsePtr = $this->has_else( $ifPtr );
+					if ( $elsePtr ) {
+						var_dump( "else", $this->tokens[ $elsePtr ] );
+						list( $expression_start, $expression_end ) = $this->get_expression_from_condition( $ifPtr );
+						list( $scope_start, $scope_end ) = $this->get_scope_from_condition( $elsePtr );
+						#var_dump( "checking else", $this->tokens_as_string( $expression_start, $expression_end ), $this->tokens_as_string( $scope_start, $scope_end ) );
+
+						if ( $this->expression_contains_and( $expression_start, $expression_end ) && $this->scope_contains_error_terminator( $scope_start, $scope_end ) ) {
+							var_dump( "error in", $this->tokens_as_string( $scope_start, $scope_end ) );
+							$this->phpcsFile->addError( 'Unsafe use of wp_verify_nonce() in expression %s.',
+								$stackPtr,
+								'UnsafeVerifyNonceElse',
+								[ $this->tokens_as_string( $expression_start, $expression_end ) ], // [ $unsafe_expression, $method, $methodParam[ 'clean' ], rtrim( "\n" . join( "\n", $extra_context ) ) ],
+								0,
+								false
+							);
+	
+						}
+	
+					}
+				}
+
+			}
+
+
+		}
+	}
+	
+}

--- a/MinimalPluginStandard/Sniffs/VerifyNonceSniff.php
+++ b/MinimalPluginStandard/Sniffs/VerifyNonceSniff.php
@@ -105,6 +105,10 @@ class VerifyNonceSniff extends Sniff {
 	 */
 	protected function is_assignment_statement( $stackPtr ) {
 		$start = $this->phpcsFile->findStartOfStatement( $stackPtr );
+		while ( !empty( $this->tokens[ $start ][ 'nested_parenthesis' ] ) ) {
+			$paren = array_key_first( $this->tokens[ $start ][ 'nested_parenthesis' ] );
+			$start = $this->phpcsFile->findStartOfStatement( $paren - 1 );
+		}
 		return $this->is_assignment( $start );
 	}
 

--- a/tests/nonce/VerifyNonceUnitTest.php
+++ b/tests/nonce/VerifyNonceUnitTest.php
@@ -23,7 +23,7 @@ class VerifyNonceUnitTest extends TestCase {
 				5,
 				11,
 				16,
-				21,
+				22,
 			], 
 			$error_lines );
 

--- a/tests/nonce/VerifyNonceUnitTest.php
+++ b/tests/nonce/VerifyNonceUnitTest.php
@@ -20,49 +20,12 @@ class VerifyNonceUnitTest extends TestCase {
 
 		$this->assertEquals(
 			[
-				14,
-				22,
-				30,
-				38,
-				45,
-				52,
-				59,
-				66,
-				75,
-				82,
-				97,
-				106,
-				113,
-				120,
-				140,
-				159,
-				168,
-				181,
-				200,
-				221,
-				258,
-				270,
-				292
+				5,
+				11,
+				16,
+				21,
 			], 
 			$error_lines );
-
-		$warning_lines = array_keys( $phpcsFile->getWarnings() );
-		$this->assertEquals(
-			[
-				89,
-				149,
-				188,
-				191,
-				196,
-				203,
-				207,
-				278,
-				279,
-				280,
-				281,
-				301
-			],
-			$warning_lines );
 
 	}
 

--- a/tests/nonce/VerifyNonceUnitTest.php
+++ b/tests/nonce/VerifyNonceUnitTest.php
@@ -23,6 +23,7 @@ class VerifyNonceUnitTest extends TestCase {
 				11,
 				16,
 				22,
+				26,
 			], 
 			$error_lines );
 

--- a/tests/nonce/VerifyNonceUnitTest.php
+++ b/tests/nonce/VerifyNonceUnitTest.php
@@ -25,6 +25,7 @@ class VerifyNonceUnitTest extends TestCase {
 				22,
 				26,
 				34,
+				38,
 			], 
 			$error_lines );
 

--- a/tests/nonce/VerifyNonceUnitTest.php
+++ b/tests/nonce/VerifyNonceUnitTest.php
@@ -1,0 +1,86 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use PHP_CodeSniffer\Files\LocalFile;
+use PHP_CodeSniffer\Ruleset;
+use PHP_CodeSniffer\Config;
+ 
+class VerifyNonceUnitTest extends TestCase {
+	public function test_unsafe_code() {
+		$fixtureFile = __FILE__ . '-bad.inc';
+		$sniffFiles = [ dirname( dirname( __DIR__ ) ) . '/MinimalPluginStandard/Sniffs/VerifyNonceSniff.php' ];
+		$config = new Config();
+		$ruleset = new Ruleset($config);
+		$ruleset->registerSniffs($sniffFiles, [], []);
+		$ruleset->populateTokenListeners();
+		$phpcsFile = new LocalFile($fixtureFile, $ruleset, $config);
+		$phpcsFile->process();
+		$foundErrors = $phpcsFile->getErrors();
+		var_dump( $foundErrors );
+		$error_lines = array_keys($foundErrors);
+
+		$this->assertEquals(
+			[
+				14,
+				22,
+				30,
+				38,
+				45,
+				52,
+				59,
+				66,
+				75,
+				82,
+				97,
+				106,
+				113,
+				120,
+				140,
+				159,
+				168,
+				181,
+				200,
+				221,
+				258,
+				270,
+				292
+			], 
+			$error_lines );
+
+		$warning_lines = array_keys( $phpcsFile->getWarnings() );
+		$this->assertEquals(
+			[
+				89,
+				149,
+				188,
+				191,
+				196,
+				203,
+				207,
+				278,
+				279,
+				280,
+				281,
+				301
+			],
+			$warning_lines );
+
+	}
+
+	public function test_safe_code() {
+		$fixtureFile = __FILE__ . '-safe.inc';
+		$sniffFiles = [ dirname( dirname( __DIR__ ) ) . '/MinimalPluginStandard/Sniffs/VerifyNonceSniff.php' ];
+		$config = new Config();
+		$ruleset = new Ruleset($config);
+		$ruleset->registerSniffs($sniffFiles, [], []);
+		$ruleset->populateTokenListeners();
+		$phpcsFile = new LocalFile($fixtureFile, $ruleset, $config);
+		$phpcsFile->process();
+		$foundErrors = $phpcsFile->getErrors();
+		var_dump( $foundErrors );
+		$lines = array_keys($foundErrors);
+
+		$this->assertEquals(
+			[],
+			$lines);
+	}
+}

--- a/tests/nonce/VerifyNonceUnitTest.php
+++ b/tests/nonce/VerifyNonceUnitTest.php
@@ -15,7 +15,6 @@ class VerifyNonceUnitTest extends TestCase {
 		$phpcsFile = new LocalFile($fixtureFile, $ruleset, $config);
 		$phpcsFile->process();
 		$foundErrors = $phpcsFile->getErrors();
-		var_dump( $foundErrors );
 		$error_lines = array_keys($foundErrors);
 
 		$this->assertEquals(
@@ -39,7 +38,6 @@ class VerifyNonceUnitTest extends TestCase {
 		$phpcsFile = new LocalFile($fixtureFile, $ruleset, $config);
 		$phpcsFile->process();
 		$foundErrors = $phpcsFile->getErrors();
-		var_dump( $foundErrors );
 		$lines = array_keys($foundErrors);
 
 		$this->assertEquals(

--- a/tests/nonce/VerifyNonceUnitTest.php
+++ b/tests/nonce/VerifyNonceUnitTest.php
@@ -24,6 +24,7 @@ class VerifyNonceUnitTest extends TestCase {
 				16,
 				22,
 				26,
+				34,
 			], 
 			$error_lines );
 

--- a/tests/nonce/VerifyNonceUnitTest.php-bad.inc
+++ b/tests/nonce/VerifyNonceUnitTest.php-bad.inc
@@ -21,3 +21,11 @@ function insecure_nonce_3() {
 function insecure_nonce_4() {
 	wp_verify_nonce( $_POST['my_nonce_field'], 'my-action' ); // unsafe!
 }
+
+function insecure_nonce_5() {
+	if ( $something || wp_verify_nonce( $_REQUEST['my-nonce'], 'post-nonce' ) ) {
+		do_something();
+	} else {
+		wp_nonce_ays();
+	}
+}

--- a/tests/nonce/VerifyNonceUnitTest.php-bad.inc
+++ b/tests/nonce/VerifyNonceUnitTest.php-bad.inc
@@ -29,3 +29,7 @@ function insecure_nonce_5() {
 		wp_nonce_ays();
 	}
 }
+
+function insecure_nonce_6() {
+	if ( ! isset( $_REQUEST['nonce'] ) && ! wp_verify_nonce( $_REQUEST['nonce'], 'nonce' ) ) return; // unsafe!
+}

--- a/tests/nonce/VerifyNonceUnitTest.php-bad.inc
+++ b/tests/nonce/VerifyNonceUnitTest.php-bad.inc
@@ -33,3 +33,11 @@ function insecure_nonce_5() {
 function insecure_nonce_6() {
 	if ( ! isset( $_REQUEST['nonce'] ) && ! wp_verify_nonce( $_REQUEST['nonce'], 'nonce' ) ) return; // unsafe!
 }
+
+function insecure_nonce_7() {
+	if (!isset($_GET['my-nonce']) && !wp_verify_nonce($_GET['my-nonce'], 'delete')) {
+		if (!current_user_can('editor') || !current_user_can('administrator')) {
+			return false;
+		}
+	}
+}

--- a/tests/nonce/VerifyNonceUnitTest.php-bad.inc
+++ b/tests/nonce/VerifyNonceUnitTest.php-bad.inc
@@ -1,0 +1,22 @@
+<?php
+
+// Nonce not checked if it's unset
+function insecure_nonce_1() {
+	if ( isset( $post_data['nonce'] ) && ! wp_verify_nonce( $post_data['nonce'], 'my_nonce' ) ) { // unsafe!
+		wp_send_json_error( new WP_Error( 'invalid_code' ) );
+	}
+}
+
+function insecure_nonce_2() {
+	if ( isset( $_REQUEST['my-nonce'] ) && ! wp_verify_nonce( $_REQUEST['my-nonce'], 'post-nonce' ) ) // unsafe!
+		die( 'Security check' );
+}
+
+function insecure_nonce_3() {
+	if ( isset( $_POST['my_nonce_field'] ) && ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['my_nonce_field'] ) ), 'my_nonce' ) ) { // unsafe!
+		return;
+}
+
+function insecure_nonce_4() {
+	wp_verify_nonce( $_POST['my_nonce_field'], 'my-action' ); // unsafe!
+}

--- a/tests/nonce/VerifyNonceUnitTest.php-bad.inc
+++ b/tests/nonce/VerifyNonceUnitTest.php-bad.inc
@@ -15,6 +15,7 @@ function insecure_nonce_2() {
 function insecure_nonce_3() {
 	if ( isset( $_POST['my_nonce_field'] ) && ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['my_nonce_field'] ) ), 'my_nonce' ) ) { // unsafe!
 		return;
+	}
 }
 
 function insecure_nonce_4() {

--- a/tests/nonce/VerifyNonceUnitTest.php-safe.inc
+++ b/tests/nonce/VerifyNonceUnitTest.php-safe.inc
@@ -41,3 +41,9 @@ function safe_example_4() {
 		die();
 	}
 }
+
+function safe_example_5() {
+	$check = wp_verify_nonce(sanitize_text_field($_POST['security']), 'my-nonce');
+	if (!$check)
+		return;
+}

--- a/tests/nonce/VerifyNonceUnitTest.php-safe.inc
+++ b/tests/nonce/VerifyNonceUnitTest.php-safe.inc
@@ -47,3 +47,8 @@ function safe_example_5() {
 	if (!$check)
 		return;
 }
+
+function safe_example_6() {
+	$is_valid = ( isset( $_POST[ 'my_nonce' ] ) && wp_verify_nonce( $_POST[ 'my_nonce' ], 'something' ) ) ? true : false;
+	return $is_valid;
+}

--- a/tests/nonce/VerifyNonceUnitTest.php-safe.inc
+++ b/tests/nonce/VerifyNonceUnitTest.php-safe.inc
@@ -18,3 +18,19 @@ function safe_example_2() {
 		// Do stuff here.
 	}
 }
+
+function safe_example_3() {
+	if ( wp_verify_nonce( $nonce, 'my-nonce' ) ) { // safe since the action is in the first clause
+		$result = do_some_stuff();
+	} else {
+		$result = 'error';
+	}
+
+	return $result;
+}
+
+function false_positive_1( $nonce ) {
+	// Helper function example
+	return wp_verify_nonce( $nonce, $this->get_nonce_action() ); // safe
+}
+

--- a/tests/nonce/VerifyNonceUnitTest.php-safe.inc
+++ b/tests/nonce/VerifyNonceUnitTest.php-safe.inc
@@ -34,3 +34,10 @@ function false_positive_1( $nonce ) {
 	return wp_verify_nonce( $nonce, $this->get_nonce_action() ); // safe
 }
 
+function safe_example_4() {
+	if ( ( wp_verify_nonce( $nonce, 'my-nonce' ) ) ) {
+		do_something();
+	} else {
+		die();
+	}
+}

--- a/tests/nonce/VerifyNonceUnitTest.php-safe.inc
+++ b/tests/nonce/VerifyNonceUnitTest.php-safe.inc
@@ -1,0 +1,20 @@
+<?php
+
+// Example from docs
+function safe_example_1() {
+	if ( isset( $_REQUEST['_wpnonce'] ) && wp_verify_nonce( $_REQUEST['_wpnonce'], 'wpdocs-my-nonce' ) ) { // safe!
+		//do you action
+	} else {
+		die( __( 'Security check', 'textdomain' ) ); 
+	}
+}
+
+// Another doc example
+function safe_example_2() {
+	$nonce = $_REQUEST['_wpnonce'];
+	if ( ! wp_verify_nonce( $nonce, 'my-nonce' ) ) {
+		die( __( 'Security check', 'textdomain' ) ); 
+	} else {
+		// Do stuff here.
+	}
+}


### PR DESCRIPTION
This checks for erroneous and unsafe use of `wp_verify_nonce()`, such as this:

```php
	if ( isset( $_REQUEST['my-nonce'] ) && ! wp_verify_nonce( $_REQUEST['my-nonce'], 'post-nonce' ) ) // unsafe!
		die( 'Security check' );
```

There's a logic bug that means the nonce check can be bypassed simply by making sure `$_REQUEST['my-nonce']` is unset.

This sniff attempts to catch this and similar bugs, without causing too many false positives on correct code. It's likely that many uses of `wp_verify_nonce()` could be replaced with `check_admin_referer()`.
