### PR TITLE
Fix/nonce check php warning

### DIFF
--- a/tests/nonce/VerifyNonceUnitTest.php
+++ b/tests/nonce/VerifyNonceUnitTest.php
@@ -30,7 +30,8 @@ class VerifyNonceUnitTest extends TestCase {
 				26,
 				34,
 				38,
-			], 
+				46,
+			],
 			$error_lines );
 
 	}

--- a/tests/nonce/VerifyNonceUnitTest.php-bad.inc
+++ b/tests/nonce/VerifyNonceUnitTest.php-bad.inc
@@ -41,3 +41,10 @@ function insecure_nonce_7() {
 		}
 	}
 }
+
+function insecure_nonce_8() {
+	if ( $something || wp_verify_nonce( $_REQUEST['my-nonce'], 'post-nonce' ) )
+		do_something();
+	else
+		wp_nonce_ays();
+}

--- a/tests/nonce/VerifyNonceUnitTest.php-safe.inc
+++ b/tests/nonce/VerifyNonceUnitTest.php-safe.inc
@@ -5,7 +5,7 @@ function safe_example_1() {
 	if ( isset( $_REQUEST['_wpnonce'] ) && wp_verify_nonce( $_REQUEST['_wpnonce'], 'wpdocs-my-nonce' ) ) { // safe!
 		//do you action
 	} else {
-		die( __( 'Security check', 'textdomain' ) ); 
+		die( __( 'Security check', 'textdomain' ) );
 	}
 }
 
@@ -13,7 +13,7 @@ function safe_example_1() {
 function safe_example_2() {
 	$nonce = $_REQUEST['_wpnonce'];
 	if ( ! wp_verify_nonce( $nonce, 'my-nonce' ) ) {
-		die( __( 'Security check', 'textdomain' ) ); 
+		die( __( 'Security check', 'textdomain' ) );
 	} else {
 		// Do stuff here.
 	}
@@ -57,13 +57,13 @@ function safe_example_7() {
 	if (  wp_verify_nonce( $_REQUEST['_wpnonce'], 'wpdocs-my-nonce-1' ) || wp_verify_nonce( $_REQUEST['_wpnonce'], 'wpdocs-my-nonce-2' ) ) { // safe!
 		//do you action
 	} else {
-		die( __( 'Security check', 'textdomain' ) ); 
+		die( __( 'Security check', 'textdomain' ) );
 	}
 }
 
 function safe_example_8() {
 	if (  !wp_verify_nonce( $_REQUEST['_wpnonce'], 'wpdocs-my-nonce-1' ) && !wp_verify_nonce( $_REQUEST['_wpnonce'], 'wpdocs-my-nonce-2' ) ) { // safe!
-		die( __( 'Security check', 'textdomain' ) ); 
+		die( __( 'Security check', 'textdomain' ) );
 	} else {
 		// do secure action
 	}
@@ -73,6 +73,13 @@ function safe_example_9() {
 	if ( wp_verify_nonce( $nonce, 'my-nonce' ) && $something_else ) {
 		// do secure action
 	} else {
-		die( __( 'Security check', 'textdomain' ) ); 
+		die( __( 'Security check', 'textdomain' ) );
 	}
+}
+
+function safe_example_10() {
+	if ( wp_verify_nonce( $nonce, 'my-nonce' ) )
+		do_something();
+	else
+		die;
 }


### PR DESCRIPTION
This fixes a bug where an if/else nonce check without a { parenthesis block } could cause a PHP warning that derailed phpcs. 

There are some related complex conditions not correctly handled by the sniff, like `if ( wp_verify_nonce() ) if ( something_else() ) die;`. But that's a separate issue to the PHP warning.