### PR TITLE
Fix a false positive caused by missing semicolons in inline code

### DIFF
--- a/MinimalPluginStandard/AbstractEscapingCheckSniff.php
+++ b/MinimalPluginStandard/AbstractEscapingCheckSniff.php
@@ -343,9 +343,10 @@ abstract class AbstractEscapingCheckSniff extends AbstractSniffHelper {
 	public function check_expression( $stackPtr, $endPtr = null ) {
 		$newPtr = $stackPtr;
 		$tokens_to_find = array(
-			\T_VARIABLE => \T_VARIABLE,
-			\T_INT_CAST => \T_INT_CAST,
+			\T_VARIABLE  => \T_VARIABLE,
+			\T_INT_CAST  => \T_INT_CAST,
 			\T_BOOL_CAST => \T_BOOL_CAST,
+			\T_CLOSE_TAG => \T_CLOSE_TAG,
 		)
 			+ Tokens::$functionNameTokens
 			+ Tokens::$textStringTokens;
@@ -466,6 +467,9 @@ abstract class AbstractEscapingCheckSniff extends AbstractSniffHelper {
 				// We're safely casting to an int or bool
 				$newPtr = $this->next_non_empty( $this->phpcsFile->findEndOfStatement( $newPtr ) );
 				continue;
+			} elseif ( \T_CLOSE_TAG === $this->tokens[ $newPtr ][ 'code' ] ) {
+				// We hit an end-of-php code without a semicolon before it, like `foo() ? >`
+				return false;
 			} elseif ( \T_CONSTANT_ENCAPSED_STRING === $this->tokens[ $newPtr ][ 'code' ] ) {
 				// A constant string is ok, but we want to check what's after it
 			}

--- a/tests/output/OutputEscapingUnitTest.php-safe.inc
+++ b/tests/output/OutputEscapingUnitTest.php-safe.inc
@@ -21,3 +21,11 @@ function safe_output_example_4( $foo ) {
 function safe_output_example_5( $foo ) {
 	echo trim( esc_url( $foo ) );
 }
+
+?>
+
+<p>safe output example 6</p>
+<h2><?php echo(esc_html(foo())) ?></h2>
+
+<?php
+$foo = bar();


### PR DESCRIPTION
See safe output example 6.

`check_expression()` wasn't terminating when some inline PHP code had a closing `?>` tag that wasn't preceded by a semicolon. This fixes the bug by explicitly terminating at a `T_CLOSE_TAG`.

This is probably a bug in the `phpcsFile->findNext()` function, since its `$local` parameter isn't aware of close tags.