### PR TITLE
Fix a common FP in WC plugins

### DIFF
--- a/MinimalPluginStandard/Sniffs/OutputEscapingSniff.php
+++ b/MinimalPluginStandard/Sniffs/OutputEscapingSniff.php
@@ -118,7 +118,7 @@ class OutputEscapingSniff extends AbstractEscapingCheckSniff {
 		'plugin_dir_url'  => true, // probably safe?
 		'admin_url'       => true, // also probably safe?
 		'get_admin_url'   => true, // probably?
-
+		'get_field_description' => true, // WP_Admin_Settings::get_field_description()
 	);
 
 	/**

--- a/tests/output/OutputEscapingUnitTest.php-safe.inc
+++ b/tests/output/OutputEscapingUnitTest.php-safe.inc
@@ -29,3 +29,12 @@ function safe_output_example_5( $foo ) {
 
 <?php
 $foo = bar();
+
+function safe_output_example_7( $data ) {
+    $field_description = WC_Admin_Settings::get_field_description($data);
+    $description = $field_description['description'];
+    $tooltip_html = $field_description['tooltip_html'];
+
+	// Safe because WC_Admin_Settings::get_field_description() uses kses.
+	echo $tooltip_html;
+}


### PR DESCRIPTION
It would be better if `$implicitSafeFunctions` understood a class prefix.