### PR TITLE
Fix/fewer output errors

### DIFF
--- a/MinimalPluginStandard/AbstractEscapingCheckSniff.php
+++ b/MinimalPluginStandard/AbstractEscapingCheckSniff.php
@@ -76,6 +76,14 @@ abstract class AbstractEscapingCheckSniff extends AbstractSniffHelper {
 	];
 
 	/**
+	 * Variable names that will always produce an error when used unescaped.
+	 * NOTE: If set, ALL OTHER INPUT will default to a warning.
+	 */
+	protected $error_always_parameters = [
+		// Use with care!
+	];
+
+	/**
 	 * Keep track of sanitized and unsanitized variables.
 	 */
 	protected $sanitized_variables = [];
@@ -513,6 +521,17 @@ abstract class AbstractEscapingCheckSniff extends AbstractSniffHelper {
 			if ( preg_match( '/^' . preg_quote( $warn_param ) . '(?:\b|$)/', $parameter_name ) ) {
 				return true;
 			}
+		}
+		// If $error_always_parameters is set, then all other variable names will produce warnings only.
+		if ( !empty( $this->error_always_parameters ) ) {
+			foreach ( $this->error_always_parameters as $error_param ) {
+				// Note the unanchored regex here. That's on purpose as a bit of a hack, so that strings like this are considered warnings:
+				// `foo( $safe_var )`
+				if ( preg_match( '/' . preg_quote( $error_param ) . '(?:\b|$)/m', $parameter_name ) ) {
+					return false;
+				}
+			}
+			return true;
 		}
 		return false;
 	}

--- a/MinimalPluginStandard/Sniffs/OutputEscapingSniff.php
+++ b/MinimalPluginStandard/Sniffs/OutputEscapingSniff.php
@@ -119,6 +119,35 @@ class OutputEscapingSniff extends AbstractEscapingCheckSniff {
 		'admin_url'       => true, // also probably safe?
 		'get_admin_url'   => true, // probably?
 		'get_field_description' => true, // WP_Admin_Settings::get_field_description()
+		'get_submit_button' => true, // returns html with escaped attributes
+		'wp_star_rating'  => true, // some misc functions from template.php that are safe enough
+		'get_settings_errors' => true,
+		'_draft_or_post_title' => true,
+		'_admin_search_query' => true,
+		'get_media_states' => true,
+		'get_post_states' => true,
+		'wp_readonly'     => true, // some misc functions from general-template.php that are safe enough
+		'get_post_timestamp' => true, // some of these return html and are thus intended to be output without escaping
+		'wp_get_code_editor_settings' => true,
+		'get_the_post_type_description' => true,
+		'has_custom_logo' => true,
+		'get_custom_logo' => true,
+		'get_language_attributes' => true,
+		'get_the_archive_title' => true,
+		'checked'         => true,
+		'selected'        => true,
+		'disabled'        => true,
+		'get_the_time'    => true,
+		'get_post_time'   => true,
+		'get_the_modified_time' => true,
+		'get_the_modified_date' => true,
+		'get_the_date'    => true,
+		'get_archives_link' => true,
+		'get_calendar'    => true,
+		'wp_nav_menu'     => true, // nav-menu-template.php
+		'get_post_format' => true,
+		'wp_get_attachment_image' => true,
+		'mysql2date'      => true,
 	);
 
 	/**

--- a/MinimalPluginStandard/Sniffs/OutputEscapingSniff.php
+++ b/MinimalPluginStandard/Sniffs/OutputEscapingSniff.php
@@ -150,6 +150,15 @@ class OutputEscapingSniff extends AbstractEscapingCheckSniff {
 		'mysql2date'      => true,
 	);
 
+	// Explicit user input will always generate an error when displayed unescaped.
+	// All other variables will generate warnings.
+	protected $error_always_parameters = [
+		'$_GET',
+		'$_POST',
+		'$_REQUEST',
+		'$_COOKIE',
+	];
+
 	/**
 	 * $wpdb methods with escaping built-in
 	 *

--- a/tests/output/OutputEscapingUnitTest.php
+++ b/tests/output/OutputEscapingUnitTest.php
@@ -23,14 +23,18 @@ class OutputEscapingUnitTest extends TestCase {
 
 		$this->assertEquals(
 			[
-				4,
-				8,
+				12,
+				16,
+				21,
 			],
 			$error_lines );
 
 		$warning_lines = array_keys( $phpcsFile->getWarnings() );
 		$this->assertEquals(
 			[
+				4,
+				8,
+				26,
 			],
 			$warning_lines );
 

--- a/tests/output/OutputEscapingUnitTest.php-bad.inc
+++ b/tests/output/OutputEscapingUnitTest.php-bad.inc
@@ -7,3 +7,21 @@ function unsafe_output_example_1( $foo ) {
 function unsafe_output_example_2( $foo ) {
 	print( addslashes( $foo ) );
 }
+
+function unsafe_output_example_3( ) {
+	echo $_POST['foo'];
+}
+
+function unsafe_output_example_4() {
+	echo trim( $_GET['bar'] );
+}
+
+function unsafe_output_example_5() {
+	// Not an output escaping function!
+	echo addslashes( $_REQUEST['foo'] );
+}
+
+function unsafe_output_example_6( $foo ) {
+	// Unsafe but just a warning.
+	echo trim( $foo );
+}


### PR DESCRIPTION
This changes the behaviour of the output escaping sniff, so it produces warnings for most things and only errors when something like `$_POST` is explicitly output.