### PR TITLE
Fix more false positives

### DIFF
--- a/MinimalPluginStandard/AbstractEscapingCheckSniff.php
+++ b/MinimalPluginStandard/AbstractEscapingCheckSniff.php
@@ -180,7 +180,7 @@ abstract class AbstractEscapingCheckSniff extends AbstractSniffHelper {
 	protected function _is_sanitized_var( $var, $context ) {
 
 		// If it's $wpdb->tablename then it's implicitly safe
-		if ( '$wpdb->' === substr( $var, 0, 7 ) || '$this->' === substr( $var, 0, 7 ) || '$wpdb' === $var ) {
+		if ( '$wpdb->' === substr( $var, 0, 7 ) || '$this->table' === substr( $var, 0, 12 ) || '$wpdb' === $var ) {
 			return true;
 		}
 

--- a/MinimalPluginStandard/AbstractEscapingCheckSniff.php
+++ b/MinimalPluginStandard/AbstractEscapingCheckSniff.php
@@ -180,7 +180,7 @@ abstract class AbstractEscapingCheckSniff extends AbstractSniffHelper {
 	protected function _is_sanitized_var( $var, $context ) {
 
 		// If it's $wpdb->tablename then it's implicitly safe
-		if ( '$wpdb->' === substr( $var, 0, 7 ) || '$this->table' === substr( $var, 0, 12 ) || '$wpdb' === $var ) {
+		if ( '$wpdb->' === substr( $var, 0, 7 ) || '$this->table' === substr( $var, 0, 12 ) || '$this->the_table' === substr( $var, 0, 16 ) || '$wpdb' === $var ) {
 			return true;
 		}
 

--- a/MinimalPluginStandard/AbstractEscapingCheckSniff.php
+++ b/MinimalPluginStandard/AbstractEscapingCheckSniff.php
@@ -537,21 +537,12 @@ abstract class AbstractEscapingCheckSniff extends AbstractSniffHelper {
 	}
 
 	/**
-	 * Is a SQL query of a type that should only produce a warning when it contains unescaped parameters?
-	 *
-	 * For example, CREATE TABLE queries usually include unescaped table and column names.
+	 * Is an expression one that should only produce a warning when it is used unescaped?
 	 */
-	public function is_warning_sql( $sql ) {
-		foreach ( $this->warn_only_queries as $warn_query ) {
-			if ( 0 === strpos( ltrim( $sql, '\'"' ), $warn_query ) ) {
-				return true;
-			}
-		}
-
+	public function is_warning_expression( $expression_string ) {
+		// Override this in child class if needed.
 		return false;
 	}
-
-
 
 	/**
 	 * Processes this test, when one of its tokens is encountered.
@@ -629,7 +620,10 @@ abstract class AbstractEscapingCheckSniff extends AbstractSniffHelper {
 					$extra_context = $this->unwind_unsafe_assignments( $unsafe_ptr );
 					$unsafe_expression = $this->get_unsafe_expression_as_string( $unsafe_ptr );
 
-					if ( $this->is_warning_parameter( $unsafe_expression ) || $this->is_suppressed_line( $checkPtr, [ 'WordPress.DB.PreparedSQL.NotPrepared', 'WordPress.DB.PreparedSQL.InterpolatedNotPrepared', 'WordPress.DB.DirectDatabaseQuery.DirectQuery', 'DB call', 'unprepared SQL', 'PreparedSQLPlaceholders replacement count'] ) ) {
+					if ( $this->is_warning_parameter( $unsafe_expression )
+						|| $this->is_suppressed_line( $checkPtr, [ 'WordPress.DB.PreparedSQL.NotPrepared', 'WordPress.DB.PreparedSQL.InterpolatedNotPrepared', 'WordPress.DB.DirectDatabaseQuery.DirectQuery', 'DB call', 'unprepared SQL', 'PreparedSQLPlaceholders replacement count'] )
+						|| $this->is_warning_expression( $methodParam[ 'clean' ] )
+						) {
 						$this->phpcsFile->addWarning( 'Unescaped parameter %s used in $wpdb->%s(%s)%s',
 							$checkPtr,
 							$this->rule_name,

--- a/MinimalPluginStandard/AbstractEscapingCheckSniff.php
+++ b/MinimalPluginStandard/AbstractEscapingCheckSniff.php
@@ -180,7 +180,7 @@ abstract class AbstractEscapingCheckSniff extends AbstractSniffHelper {
 	protected function _is_sanitized_var( $var, $context ) {
 
 		// If it's $wpdb->tablename then it's implicitly safe
-		if ( '$wpdb->' === substr( $var, 0, 7 ) || '$this->table' === substr( $var, 0, 12 ) || '$wpdb' === $var ) {
+		if ( '$wpdb->' === substr( $var, 0, 7 ) || '$this->' === substr( $var, 0, 7 ) || '$wpdb' === $var ) {
 			return true;
 		}
 

--- a/MinimalPluginStandard/Sniffs/DirectDBSniff.php
+++ b/MinimalPluginStandard/Sniffs/DirectDBSniff.php
@@ -38,6 +38,7 @@ class DirectDBSniff extends AbstractEscapingCheckSniff {
 		'esc_sql'                    => true,
 		'wp_parse_id_list'           => true,
 		'bp_esc_like'                => true,
+		'sanitize_sql_orderby'       => true,
 	);
 
 	/**

--- a/MinimalPluginStandard/Sniffs/DirectDBSniff.php
+++ b/MinimalPluginStandard/Sniffs/DirectDBSniff.php
@@ -194,4 +194,22 @@ class DirectDBSniff extends AbstractEscapingCheckSniff {
 		);
 	}
 
+
+
+
+	/**
+	 * Is a SQL query of a type that should only produce a warning when it contains unescaped parameters?
+	 *
+	 * For example, CREATE TABLE queries usually include unescaped table and column names.
+	 */
+	public function is_warning_expression( $sql ) {
+		foreach ( $this->warn_only_queries as $warn_query ) {
+			if ( 0 === strpos( ltrim( $sql, '\'"' ), $warn_query ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 }

--- a/MinimalPluginStandard/Sniffs/DirectDBSniff.php
+++ b/MinimalPluginStandard/Sniffs/DirectDBSniff.php
@@ -91,6 +91,7 @@ class DirectDBSniff extends AbstractEscapingCheckSniff {
 		'rand'           => true,
 		'mt_rand'        => true,
 		'max'            => true,
+		'table_name'     => true,
 	);
 
 	/**

--- a/tests/db/DirectDBUnitTest.php-safe.inc
+++ b/tests/db/DirectDBUnitTest.php-safe.inc
@@ -467,3 +467,9 @@ function false_positive_23() {
 			)
 	);
 }
+
+function false_positive_24() {
+	global $wpdb;
+	$wpdb->query( "delete from " . WCSC::table_name() );
+	$wpdb->query( "delete from " . WCSC_Error_Logs::table_name() );
+}

--- a/tests/db/DirectDBUnitTest.php-safe.inc
+++ b/tests/db/DirectDBUnitTest.php-safe.inc
@@ -491,3 +491,8 @@ function false_positive_26( $foo_id ) {
 
 		return (int) $this->wpdb->get_var( $query );
 }
+
+function false_positive_27() {
+	$wpdb->query( $wpdb->prepare( "SELECT * FROM $wpdb->foo WHERE foo = %s", ( 1 == $bar ? $foo : '' ) ) );
+	$wpdb->query( $wpdb->prepare( "SELECT * FROM $wpdb->foo WHERE foo = %s", $foo );
+}

--- a/tests/db/DirectDBUnitTest.php-safe.inc
+++ b/tests/db/DirectDBUnitTest.php-safe.inc
@@ -447,3 +447,23 @@ function false_positive_22( $interval_in_days ) {
 	return $deleted_rows_count;
 
 }
+
+function false_positive_23() {
+	global $wpdb;
+	$wpdb->query(
+			$wpdb->prepare(
+					'INSERT INTO ec_address( `user_id`, `first_name`, `last_name`, `company_name`, `address_line_1`, `address_line_2`, `city`, `state`, `zip`, `country`, `phone` ) VALUES( %d, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s )',
+					$user_id,
+					( ( -1 != $billing_first_name_index ) ? $rows[ $i ][ $billing_first_name_index ] : '' ),
+					( ( -1 != $billing_last_name_index ) ? $rows[ $i ][ $billing_last_name_index ] : '' ),
+					( ( -1 != $billing_company_name_index ) ? $rows[ $i ][ $$billing_company_name_index ] : '' ),
+					( ( -1 != $billing_address_line_1_index ) ? $rows[ $i ][ $billing_address_line_1_index ] : '' ),
+					( ( -1 != $billing_address_line_2_index ) ? $rows[ $i ][ $billing_address_line_2_index ] : '' ),
+					( ( -1 != $billing_city_index ) ? $rows[ $i ][ $billing_city_index ] : '' ),
+					( ( -1 != $billing_state_index ) ? $rows[ $i ][ $billing_state_index ] : '' ),
+					( ( -1 != $billing_zip_index ) ? $rows[ $i ][ $billing_zip_index ] : '' ),
+					( ( -1 != $billing_country_index ) ? $rows[ $i ][ $billing_country_index ] : '' ),
+					( ( -1 != $billing_phone_index ) ? $rows[ $i ][ $billing_phone_index ] : '' )
+			)
+	);
+}

--- a/tests/db/DirectDBUnitTest.php-safe.inc
+++ b/tests/db/DirectDBUnitTest.php-safe.inc
@@ -473,3 +473,9 @@ function false_positive_24() {
 	$wpdb->query( "delete from " . WCSC::table_name() );
 	$wpdb->query( "delete from " . WCSC_Error_Logs::table_name() );
 }
+
+function false_positive_25( $tables ) {
+	global $wpdb;
+	// Should be ignored because it's a DROP TABLE.
+	$wpdb->query( 'DROP TABLE ' . implode( ',', $tables ) );
+}

--- a/tests/db/DirectDBUnitTest.php-safe.inc
+++ b/tests/db/DirectDBUnitTest.php-safe.inc
@@ -479,3 +479,15 @@ function false_positive_25( $tables ) {
 	// Should be ignored because it's a DROP TABLE.
 	$wpdb->query( 'DROP TABLE ' . implode( ',', $tables ) );
 }
+
+function false_positive_26( $foo_id ) {
+		$query = $this->wpdb->prepare(
+					"
+					SELECT the_id
+					FROM $this->the_table
+					WHERE foo_id = %d",
+					$foo_id
+			);
+
+		return (int) $this->wpdb->get_var( $query );
+}


### PR DESCRIPTION
This fixes several recent false positives, including a tricky one involving ternary expressions.

See unit tests for examples.