### PR TITLE
Don't link to trac for uploaded file scan results

### DIFF
--- a/admin/class-scan-metabox.php
+++ b/admin/class-scan-metabox.php
@@ -36,6 +36,7 @@ class Scan_Metabox {
 		}
 
 		$tag_dir          = ( 'trunk' === $post->stable_tag || '' == $post->stable_tag ? 'trunk' : 'tags/' . $post->stable_tag );
+		$upload_dir       = wp_get_upload_dir();
 		$is_uploaded_file = str_starts_with( $results['file'], $upload_dir['basedir'] );
 
 		echo '<pre style="white-space: pre-wrap;">';

--- a/includes/class-scanner.php
+++ b/includes/class-scanner.php
@@ -23,8 +23,6 @@ class Scanner {
 
 	public static function get_scan_results_for_zip( $zip_file_path ) {
 
-		$out = wp_cache_get( $zip_file_path, 'wporg-code-analysis-scan' );
-
 		// Note that unzip() automatically removes the temp directory on shutdown
 		$unzip_dir = Filesystem::unzip( $zip_file_path );
 
@@ -83,10 +81,7 @@ class Scanner {
 		}
 
 		$result['hash'] = self::get_result_hash( $result );
-
 		$result['file'] = $zip_file_path;
-
-		//TODO: cache this?
 
 		return $result;
 	}

--- a/includes/class-scanner.php
+++ b/includes/class-scanner.php
@@ -84,6 +84,8 @@ class Scanner {
 
 		$result['hash'] = self::get_result_hash( $result );
 
+		$result['file'] = $zip_file_path;
+
 		//TODO: cache this?
 
 		return $result;


### PR DESCRIPTION
 - Avoids a PHP Notice when the ZIP contains just 'file.php': `E_NOTICE: Undefined offset: 1 in plugins/wporg-code-analysis/admin/class-scan-metabox.php:42`
 - Avoids linking to Trac for files that were not likely in SVN
 - Removes some unused caching